### PR TITLE
Update LabMachine.json

### DIFF
--- a/01-configuring-your-aws-account/LabMachine.json
+++ b/01-configuring-your-aws-account/LabMachine.json
@@ -78,7 +78,7 @@
           "yum update -y aws-cfn-bootstrap\n",
           "yum install -y gcc\n",
           "pip install boto3\n",
-          "pip install fake-factory\n",
+          "pip install Faker\n",
           "pip install tqdm\n",
           "pip install multiprocessing\n",
 


### PR DESCRIPTION
When I attempted to run `datamodelv1.py` from `05-case-study-setup-data-model-v1` on the ec2 LabMachine instance it errored:

```
  File "./datamodelv1.py", line 20, in <module>
    from faker import Factory
  File "/usr/local/lib/python2.7/site-packages/faker/__init__.py", line 7, in <module>
    raise ImportError(error)
ImportError: The ``fake-factory`` package is now called ``Faker``.

Please update your requirements.
```

Updating the package name in `01-configuring-your-aws-account/LabMachine.json` fixed the issue for me.